### PR TITLE
[DEV] Add `strict_val` keyword that prevents models from using the validation data for validation

### DIFF
--- a/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
+++ b/timeseries/src/autogluon/timeseries/models/gluonts/abstract_gluonts.py
@@ -486,6 +486,12 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         )
         self._deferred_init_params_aux(train_data)
 
+        if init_args.get("strict_val", False):
+            print("Being strict about the train val split!")
+            train_data, val_data = train_data.train_test_split(self.prediction_length)
+        else:
+            print("Not being strict about the train val split.")
+
         estimator = self._get_estimator()
         with warning_filter(), disable_root_logger(), gluonts.core.settings.let(gluonts.env.env, use_tqdm=False):
             self.gts_predictor = estimator.train(
@@ -636,4 +642,4 @@ class AbstractGluonTSModel(AbstractTimeSeriesModel):
         return TimeSeriesDataFrame(forecast_df)
 
     def _more_tags(self) -> dict:
-        return {"allow_nan": True, "can_use_val_data": True}
+        return {"allow_nan": True, "can_use_val_data": True, "can_refit_full": True}

--- a/timeseries/src/autogluon/timeseries/predictor.py
+++ b/timeseries/src/autogluon/timeseries/predictor.py
@@ -1432,6 +1432,7 @@ class TimeSeriesPredictor(TimeSeriesPredictorDeprecatedMixin):
         base_models = trainer.get_model_names(level=0)
         pred_proba_dict_val: Dict[str, List[TimeSeriesDataFrame]] = {
             model: trainer._get_model_oof_predictions(model) for model in base_models
+            if "_FULL" not in model
         }
 
         past_data, known_covariates = test_data.get_model_inputs_for_scoring(


### PR DESCRIPTION
When fitting a model, validation data can be used for hyperparameter tuning or early stopping. But when fitting ensembles, we typically assume that validation data has not been seen at all, as we use it to assess the test performance of base models. To experiment with this, this PR aims to implement two things:
- a `strict_val` option which makes sure that the "validation data" is not seen by the base models at all
- a `_refit_full` option that re-trains the model on the default train/val split, as otherwise we would have worse test performance

Both of these are implemented inside `MultiWindowBacktestingModel`; see the comments in the code below. All changes outside of `multi_window_model.py` are merely there to pass the keyword arguments around.

**Current status:**
The `strict_val` option seems to work as expected, i.e. we observe a higher validation error when we set it to true.
However, `_refit_full` is currently not working yet as it _increases_ test error, so this needs to be fixed and comments would be helpful.